### PR TITLE
Make it possible to disable async search indexing requests.

### DIFF
--- a/app/conf/app.conf
+++ b/app/conf/app.conf
@@ -891,6 +891,7 @@ quicksearch_dont_open_results_panel_automatically = 0
 # Switch to disable out of process search indexing
 #
 disable_out_of_process_search_indexing = 0
+run_indexing_queue = 1
 
 # Hostname to use when triggering out of process indexing
 # By default the site hostname configured in setup.php is used but you can override it

--- a/app/lib/Controller/Request/RequestHTTP.php
+++ b/app/lib/Controller/Request/RequestHTTP.php
@@ -709,7 +709,7 @@ class RequestHTTP extends Request {
 			}
 			
 			// trigger async search indexing
-			if((__CA_APP_TYPE__ === 'PROVIDENCE') && !$this->getAppConfig()->get('disable_out_of_process_search_indexing')) {
+			if((__CA_APP_TYPE__ === 'PROVIDENCE') && !$this->getAppConfig()->get('disable_out_of_process_search_indexing') && $this->getAppConfig()->get('run_indexing_queue') ) {
                 require_once(__CA_MODELS_DIR__."/ca_search_indexing_queue.php");
                 if (!ca_search_indexing_queue::lockExists()) {
                 	$dont_verify_ssl_cert = (bool)$this->getAppConfig()->get('out_of_process_search_indexing_dont_verify_ssl_cert');


### PR DESCRIPTION
* Does not disable the queue, just the requests that happen at the very end of _every_ _single_ _page_ _call_.