### PR TITLE
[provcau-110] Update track processing widget

### DIFF
--- a/app/widgets/trackProcessing/trackProcessingWidget.php
+++ b/app/widgets/trackProcessing/trackProcessingWidget.php
@@ -89,8 +89,8 @@
 				LEFT JOIN ca_users u ON u.user_id = tq.user_id 
 				WHERE tq.completed_on > ?
 				ORDER BY tq.completed_on desc
-				LIMIT 100
-			", time() - (60*60*$pa_settings['hours']));
+				LIMIT ?
+			", time() - (60*60*$pa_settings['hours']), $this->opn_limit);
 			$va_completed = array();
 			$vn_reported = 0;
 

--- a/app/widgets/trackProcessing/trackProcessingWidget.php
+++ b/app/widgets/trackProcessing/trackProcessingWidget.php
@@ -78,7 +78,9 @@
 			
 			$vo_tq = new TaskQueue();
 			$qr_completed = $this->opo_db->query("
-				SELECT tq.*, u.fname, u.lname 
+				SELECT 
+				    tq.task_id, tq.handler, tq.created_on, tq.completed_on, tq.error_code,
+				    tq.notes, u.fname, u.lname , u.fname, u.lname 
 				FROM ca_task_queue tq 
 				LEFT JOIN ca_users u ON u.user_id = tq.user_id 
 				WHERE tq.completed_on > ? 


### PR DESCRIPTION
provcau-110 Update track processing widget to fetch a maximum of 100 rows to stop time out.
Depending on how long it's been since you've processed a large amount of records in the task queue you may need to update the number of hours setting. 
![image](https://github.com/gaiaresources/providence/assets/117886212/22204c5c-e056-4236-b04c-0034fdc6e493)
