### PR TITLE
PROVCAU-150 Refactor error handling in SQL search plugin

### DIFF
--- a/app/lib/Plugins/SearchEngine/SqlSearch2.php
+++ b/app/lib/Plugins/SearchEngine/SqlSearch2.php
@@ -616,7 +616,9 @@ class WLPlugSearchEngineSqlSearch2 extends BaseSearchPlugin implements IWLPlugSe
 		$field_lc = mb_strtolower($field);
 		$field_elements = explode('.', $field_lc);
 		if ($this->isChangeLog($field)) {
-			if (!$this->tep->parse($text)) { return []; }
+			if (!$this->tep->parse($text)) {
+				throw new SearchException(_t('Could not perform search as could not parse date: %1', $text));
+			}
 			$range = $this->tep->getUnixTimestamps();
 			$user_id = null;
 			$user_sql = '';


### PR DESCRIPTION
Modified the error handling in the SqlSearch2.php file, specifically within the isChangeLog function. If the text input cannot be parsed, now it throws a SearchException with an informative error message instead of simply returning an empty array. The change facilitates debugging and provides clearer information to the user about the potential issues with their input, enhancing the usability and robustness of the search engine.