### PR TITLE
Don't execute searches until we have the complete query

### DIFF
--- a/app/lib/Plugins/SearchEngine/SqlSearch2.php
+++ b/app/lib/Plugins/SearchEngine/SqlSearch2.php
@@ -450,11 +450,6 @@ class WLPlugSearchEngineSqlSearch2 extends BaseSearchPlugin implements IWLPlugSe
 						{$private_sql}
 				")->setArguments($params);
 			}
-			$query->execute();
-			if (!$query->getNumRecords()) {
-				// We may as well stop here as there are no results
-				return $query;
-			}
 			$results[$i] = $query;
 		}
 		// Use the first query as the basis of the search
@@ -592,7 +587,6 @@ class WLPlugSearchEngineSqlSearch2 extends BaseSearchPlugin implements IWLPlugSe
 				$i++;
 			}
 		}
-		$search_query->execute();
 		return $search_query;
 	}
 	# -------------------------------------------------------

--- a/app/lib/Plugins/SearchEngine/SqlSearch2/SearchQuery.php
+++ b/app/lib/Plugins/SearchEngine/SqlSearch2/SearchQuery.php
@@ -314,7 +314,7 @@ class SearchQuery implements Iterator, Countable {
 		
 AND_QUERY;
 
-		return $this->appendArgumentsAndExecute( $hits );
+		return $this->appendArguments( $hits );
 	}
 
 	public function addNot( SearchQuery $hits ): SearchQuery {
@@ -332,7 +332,7 @@ AND_QUERY;
 		WHERE $newWithTableName.row_id IS NULL
 NOT_QUERY;
 
-		return $this->appendArgumentsAndExecute( $hits );
+		return $this->appendArguments( $hits );
 	}
 
 	public function addOr( SearchQuery $hits ): SearchQuery {
@@ -350,7 +350,7 @@ NOT_QUERY;
 		GROUP BY row_id
 OR_QUERY;
 
-		return $this->appendArgumentsAndExecute( $hits );
+		return $this->appendArguments( $hits );
 	}
 
 	/**
@@ -368,11 +368,9 @@ OR_QUERY;
 	 *
 	 * @return $this
 	 */
-	public function appendArgumentsAndExecute( SearchQuery $hits ): SearchQuery {
+	public function appendArguments( SearchQuery $hits ): SearchQuery {
 
 		$this->addArguments( $hits->getArguments() );
-
-		$this->execute();
 
 		return $this;
 	}


### PR DESCRIPTION
* We were repeating searches for both the original subqueries and then the final filtered query.
* These were taking some time as evidenced by search logs
* This replaces that with a single call to execute the query when the final search is run.