### PR TITLE
Suppress empty Pawtucket Process spam.

### DIFF
--- a/app/plugins/pawtucketMediaImport/pawtucketMediaImportPlugin.php
+++ b/app/plugins/pawtucketMediaImport/pawtucketMediaImportPlugin.php
@@ -56,7 +56,11 @@
 		 */
 		public function hookPeriodicTask() {
 			$ret = ca_media_upload_sessions::processSessions(['limit' => 20]);
-			$this->opo_log->logInfo(__CLASS__ . ": Processed $ret sessions");
+
+			// Suppress empty process logs
+			if ($ret && $ret > 0) {
+				$this->opo_log->logInfo(__CLASS__ . ": Processed $ret sessions");
+			}
 			// Allow plugins after pawtuckeMediaImport to also process
 			return true;
 		}


### PR DESCRIPTION
@kehh  we briefly talked about getting rid of this spam.

This approach will only print process logs if there is a value. I'm not sure on the context of this, so not sure what the best approach is.

Is this being used? Can we disable the plugin entirely? or perhaps the Periodic task? If this isn't doing something we need, it might help with performance to completely remove/disable it.
Do we want a config option to suppress these? do we want to suppress even if there is a value?