### PR TITLE
Improvements to content indexing

### DIFF
--- a/app/helpers/searchHelpers.php
+++ b/app/helpers/searchHelpers.php
@@ -2260,9 +2260,9 @@
 	function caTokenizeString(?string $value) : array {
 		$search_engine_class = SearchBase::searchEngineClassName();
 		
-		if(method_exists('SearchBase', $search_engine_class)) {
+		if(method_exists($search_engine_class, 'tokenize')) {
 			return $search_engine_class::tokenize($value);
-		} else {	// Any plugin that doesn't define its own tokenizer (like ElasticSearch) uses the SqlSearch2 tokenizer by default
+		} else {	// Any plugin that doesn't define its own tokenizer uses the SqlSearch2 tokenizer by default
 			require_once(__CA_LIB_DIR__.'/Plugins/SearchEngine/SqlSearch2.php');
 			return WLPlugSearchEngineSqlSearch2::tokenize($value);
 		}

--- a/app/lib/Plugins/SearchEngine/Elastic8.php
+++ b/app/lib/Plugins/SearchEngine/Elastic8.php
@@ -149,7 +149,7 @@ class WLPlugSearchEngineElastic8 extends BaseSearchPlugin implements IWLPlugSear
 					'_source' => [
 						'enabled' => true,
 					],
-					'dynamic' => "true",
+					'dynamic' => true,
 					'dynamic_templates' => $mapping->getDynamicTemplates(),
 				]
 			];
@@ -745,7 +745,23 @@ class WLPlugSearchEngineElastic8 extends BaseSearchPlugin implements IWLPlugSear
 	public function engineName(): string {
 		return 'Elastic8';
 	}
-
+	/**
+	 * Tokenize string for indexing or search
+	 *
+	 * @param string $content
+	 * @param bool $for_search
+	 * @param int $index
+	 *
+	 * @return array Tokenized terms
+	 */
+	static public function tokenize(?string $content, ?bool $for_search=false, ?int $index=0) : array {
+		$content = preg_replace('![\']+!u', '', $content);		// strip apostrophes for compatibility with SearchEngine class, which does the same to all search expressions
+		$words = [$content];
+		return $words;
+		// TODO: do we need to implement stopwords or can ElasticSearch do this?
+		$words = self::filterStopWords($words);
+		return $words;
+	}
 	/**
 	 * Performs the quickest possible search on the index for the specified table_num in $table_num
 	 * using the text in $ps_search. Unlike the search() method, quickSearch doesn't support

--- a/app/lib/Plugins/SearchEngine/Elastic8.php
+++ b/app/lib/Plugins/SearchEngine/Elastic8.php
@@ -221,14 +221,7 @@ class WLPlugSearchEngineElastic8 extends BaseSearchPlugin implements IWLPlugSear
 				$content_row_id);
 		}
 
-		if ((
-				sizeof(self::$doc_content_buffer) +
-				sizeof(self::$update_content_buffer) +
-				sizeof(self::$delete_buffer)
-			) > $this->getOption('maxIndexingBufferSize')
-		) {
-			$this->flushContentBuffer();
-		}
+		$this->flushBufferWhenFull();
 	}
 
 	/**
@@ -502,14 +495,7 @@ class WLPlugSearchEngineElastic8 extends BaseSearchPlugin implements IWLPlugSear
 		unset($this->indexing_subject_row_id);
 		unset($this->indexing_subject_tablename);
 
-		if ((
-				sizeof(self::$doc_content_buffer) +
-				sizeof(self::$update_content_buffer) +
-				sizeof(self::$delete_buffer)
-			) > $this->getOption('maxIndexingBufferSize')
-		) {
-			$this->flushContentBuffer();
-		}
+		$this->flushBufferWhenFull();
 	}
 
 	/**
@@ -797,5 +783,23 @@ class WLPlugSearchEngineElastic8 extends BaseSearchPlugin implements IWLPlugSear
 
 	public function isReindexing(): bool {
 		return (defined('__CollectiveAccess_IS_REINDEXING__') && __CollectiveAccess_IS_REINDEXING__);
+	}
+
+	/**
+	 * @return void
+	 * @throws ApplicationException
+	 * @throws AuthenticationException
+	 * @throws ClientResponseException
+	 * @throws ServerResponseException
+	 */
+	private function flushBufferWhenFull(): void {
+		if ((
+				sizeof(self::$doc_content_buffer) +
+				sizeof(self::$update_content_buffer) +
+				sizeof(self::$delete_buffer)
+			) > $this->getOption('maxIndexingBufferSize')
+		) {
+			$this->flushContentBuffer();
+		}
 	}
 }

--- a/app/lib/Plugins/SearchEngine/Elastic8/Field.php
+++ b/app/lib/Plugins/SearchEngine/Elastic8/Field.php
@@ -35,6 +35,7 @@ namespace Elastic8;
 use Datamodel;
 use Elastic8\FieldTypes\FieldType;
 use Exception;
+use MemoryCacheInvalidParameterException;
 
 require_once(__CA_APP_DIR__ . '/helpers/listHelpers.php');
 
@@ -57,21 +58,21 @@ class Field {
 	/**
 	 * Field constructor.
 	 *
-	 * @throws Exception
+	 * @throws FieldException|MemoryCacheInvalidParameterException
 	 */
 	public function __construct(int $content_tablenum, string $indexing_fieldname) {
 		$this->content_tablenum = $content_tablenum;
 		$this->content_tablename = Datamodel::getTableName($this->getContentTableNum());
 
 		if (!$this->content_tablename) {
-			throw new Exception(_t('Invalid table num %1', $content_tablenum));
+			throw new FieldException(_t('Invalid table num %1', $content_tablenum));
 		}
 
 		$this->field_type = FieldTypes\FieldType::getInstance($this->getContentTableName(),
 			$indexing_fieldname);
 
 		if (!($this->field_type instanceof FieldTypes\FieldType)) {
-			throw new Exception(_t('Could not disambiguate field type for content table name %1 indexing field name %2',
+			throw new FieldException(_t('Could not disambiguate field type for content table name %1 indexing field name %2',
 				$content_tablenum, $indexing_fieldname));
 		}
 	}
@@ -91,3 +92,5 @@ class Field {
 		return $this->field_type->getIndexingFragment($content, $options);
 	}
 }
+
+class FieldException extends Exception {}

--- a/app/lib/Search/SearchBase.php
+++ b/app/lib/Search/SearchBase.php
@@ -40,11 +40,11 @@ require_once(__CA_LIB_DIR__."/Db.php");
 	
 class SearchBase extends BaseFindEngine {
 	# ------------------------------------------------
-	protected $opo_db;
-	protected $opo_app_config;
-	protected $opo_search_config;
-	protected $opo_search_indexing_config;
-	protected $opo_engine;
+	protected Db $opo_db;
+	protected Configuration $opo_app_config;
+	protected Configuration $opo_search_config;
+	protected Configuration $opo_search_indexing_config;
+	protected ?IWLPlugSearchEngine $opo_engine;
 	
 	static $s_fields_to_index_cache = array();
 	# ------------------------------------------------
@@ -75,9 +75,9 @@ class SearchBase extends BaseFindEngine {
 	 *
 	 * @param string $plugin_name A valid plugin file name (eg. 'ElasticSearch'), not the actual class name (eg. WLPlugSearchEngineElasticSearch)
 	 * @param Db $db Database connection to use. [Default is null]
-	 * @return WLPlugSearchEngine instance or null if engine is invalid
+	 * @return IWLPlugSearchEngine|null instance or null if engine is invalid
 	 */
-	static public function newSearchEngine($plugin_name=null, $db=null) {		
+	static public function newSearchEngine($plugin_name=null, $db=null) {
 		if (!$plugin_name) {
 			$plugin_name = self::searchEngineName();
 		}


### PR DESCRIPTION
Not directly against PROVES-58 but rather some bugfixes and tidyup for general indexing. There's an IDNO fix in there because idnos were being indexed like:

```json
["VPRS 18654", "VPRS", "V", "P", "R", "S", "1", "8", "6", "5", "4"]
```

This now indexes them as:

```json
["VPRS 18654", "VPRS"]
```