### PR TITLE
PROVES-31 Change indexed record data structures

### DIFF
--- a/app/lib/Plugins/SearchEngine/Elastic8/FieldTypes/Currency.php
+++ b/app/lib/Plugins/SearchEngine/Elastic8/FieldTypes/Currency.php
@@ -38,16 +38,9 @@ use Zend_Search_Lucene_Index_Term;
 require_once(__CA_LIB_DIR__ . '/Plugins/SearchEngine/Elastic8/FieldTypes/GenericElement.php');
 
 class Currency extends GenericElement {
-
-	public function __construct($table_name, $element_code) {
-		parent::__construct($table_name, $element_code);
-	}
-
 	public function getIndexingFragment($content, array $options): array {
-		if (is_array($content)) {
-			$content = serialize($content);
-		}
-		if ($content == '') {
+		$content = $this->serializeIfArray($content);
+		if ($content === '') {
 			return parent::getIndexingFragment($content, $options);
 		}
 
@@ -57,9 +50,10 @@ class Currency extends GenericElement {
 
 		if (is_array($parsed_currency) && isset($parsed_currency['value_decimal1'])) {
 			return [
-				$this->getTableName() . '/' . $this->getElementCode() => $parsed_currency['value_decimal1'],
-				$this->getTableName() . '/' . $this->getElementCode()
-				. '_currency' => $parsed_currency['value_longtext1'],
+				$this->getKey() => [
+					$this->getDataTypeSuffix(self::SUFFIX_CURRENCY) => $parsed_currency['value_decimal1'],
+					$this->getDataTypeSuffix(self::SUFFIX_TEXT) => $parsed_currency['value_longtext1']
+				],
 			];
 		} else {
 			return parent::getIndexingFragment($content, $options);

--- a/app/lib/Plugins/SearchEngine/Elastic8/FieldTypes/GenericElement.php
+++ b/app/lib/Plugins/SearchEngine/Elastic8/FieldTypes/GenericElement.php
@@ -69,9 +69,7 @@ class GenericElement extends FieldType {
 	}
 
 	public function getIndexingFragment($content, array $options): array {
-		if (is_array($content)) {
-			$content = serialize($content);
-		}
+		$content = $this->serializeIfArray($content);
 		// make sure empty strings are indexed as null, so ElasticSearch's
 		// _missing_ and _exists_ filters work as expected. If a field type
 		// needs to have them indexed differently, it can do so in its own
@@ -81,7 +79,7 @@ class GenericElement extends FieldType {
 		}
 
 		return [
-			$this->getTableName() . '/' . $this->getElementCode() => $content
+			$this->getKey() =>[ $this->getDataTypeSuffix() => $content]
 		];
 	}
 
@@ -105,5 +103,12 @@ class GenericElement extends FieldType {
 		} else {
 			return $term;
 		}
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getKey(): string {
+		return $this->getTableName() . '/' . $this->getElementCode();
 	}
 }

--- a/app/lib/Plugins/SearchEngine/Elastic8/FieldTypes/Length.php
+++ b/app/lib/Plugins/SearchEngine/Elastic8/FieldTypes/Length.php
@@ -39,15 +39,10 @@ require_once(__CA_LIB_DIR__ . '/Plugins/SearchEngine/Elastic8/FieldTypes/Generic
 
 class Length extends GenericElement {
 
-	public function __construct($table_name, $element_code) {
-		parent::__construct($table_name, $element_code);
-	}
-
 	public function getIndexingFragment($content, array $options): array {
-		if (is_array($content)) {
-			$content = serialize($content);
-		}
-		if ($content == '') {
+		$this->setDefaultSuffix(self::SUFFIX_DOUBLE);
+		$content = $this->serializeIfArray($content);
+		if ($content === '') {
 			return parent::getIndexingFragment($content, $options);
 		}
 
@@ -58,6 +53,7 @@ class Length extends GenericElement {
 			return parent::getIndexingFragment((float) $parsed_length->convertTo('METER', 6, 'en_US'),
 				$options);
 		} catch (Exception $e) {
+			self::getLogger()->logError(__METHOD__ . ': ' . $e->getMessage());
 			return [];
 		}
 	}
@@ -88,6 +84,7 @@ class Length extends GenericElement {
 				$term->field
 			);
 		} catch (Exception $e) {
+			self::getLogger()->logError(__METHOD__ . ': ' . $e->getMessage());
 			return $term;
 		}
 	}

--- a/app/lib/Plugins/SearchEngine/Elastic8/FieldTypes/ListItem.php
+++ b/app/lib/Plugins/SearchEngine/Elastic8/FieldTypes/ListItem.php
@@ -34,13 +34,10 @@ namespace Elastic8\FieldTypes;
 
 require_once(__CA_LIB_DIR__ . '/Plugins/SearchEngine/Elastic8/FieldTypes/GenericElement.php');
 
-class Integer extends GenericElement {
-
-
+class ListItem extends GenericElement {
 	public function getIndexingFragment($content, array $options): array {
-
+		$this->setDefaultSuffix(self::SUFFIX_KEYWORD);
 		$content = $this->serializeIfArray($content);
-		$this->setDefaultSuffix(self::SUFFIX_INTEGER);
-		return parent::getIndexingFragment((int) $content, $options);
+		return parent::getIndexingFragment($content, $options);
 	}
 }

--- a/app/lib/Plugins/SearchEngine/Elastic8/FieldTypes/Numeric.php
+++ b/app/lib/Plugins/SearchEngine/Elastic8/FieldTypes/Numeric.php
@@ -35,16 +35,10 @@ namespace Elastic8\FieldTypes;
 require_once(__CA_LIB_DIR__ . '/Plugins/SearchEngine/Elastic8/FieldTypes/GenericElement.php');
 
 class Numeric extends GenericElement {
-
-	public function __construct($table_name, $element_code) {
-		parent::__construct($table_name, $element_code);
-	}
-
 	public function getIndexingFragment($content, array $options): array {
-		if (is_array($content)) {
-			$content = serialize($content);
-		}
-		if ($content == '') {
+		$this->setDefaultSuffix(self::SUFFIX_FLOAT);
+		$content = $this->serializeIfArray($content);
+		if ($content === '') {
 			return parent::getIndexingFragment($content, $options);
 		}
 

--- a/app/lib/Plugins/SearchEngine/Elastic8/FieldTypes/Timecode.php
+++ b/app/lib/Plugins/SearchEngine/Elastic8/FieldTypes/Timecode.php
@@ -36,14 +36,8 @@ require_once(__CA_LIB_DIR__ . '/Plugins/SearchEngine/Elastic8/FieldTypes/Generic
 
 class Timecode extends GenericElement {
 
-	public function __construct($table_name, $element_code) {
-		parent::__construct($table_name, $element_code);
-	}
-
 	public function getIndexingFragment($content, array $options): array {
-		if (is_array($content)) {
-			$content = serialize($content);
-		}
+		$content = $this->serializeIfArray($content);
 
 		return parent::getIndexingFragment((float) $content, $options);
 	}

--- a/app/lib/Plugins/SearchEngine/Elastic8/FieldTypes/Timestamp.php
+++ b/app/lib/Plugins/SearchEngine/Elastic8/FieldTypes/Timestamp.php
@@ -63,12 +63,10 @@ class Timestamp extends FieldType {
 	 * @param mixed $content
 	 */
 	public function getIndexingFragment($content, array $options): array {
-		if (is_array($content)) {
-			$content = serialize($content);
-		}
+		$content = $this->serializeIfArray($content);
 
 		return [
-			str_replace('.', '/', $this->getFieldName()) => $content
+			$this->getKey() => $content
 		];
 	}
 
@@ -106,7 +104,7 @@ class Timestamp extends FieldType {
 		return $return;
 	}
 
-	function getFiltersForTerm(Zend_Search_Lucene_Index_Term $term): array {
+	public function getFiltersForTerm(Zend_Search_Lucene_Index_Term $term): array {
 		$return = [];
 		$parsed_values = caGetISODates($term->text);
 		$fld = str_replace('\\', '', $term->field);
@@ -128,5 +126,9 @@ class Timestamp extends FieldType {
 		];
 
 		return $return;
+	}
+
+	public function getKey():string {
+		return str_replace('.', '/', $this->getFieldName());
 	}
 }

--- a/app/lib/Plugins/SearchEngine/Elastic8/FieldTypes/Weight.php
+++ b/app/lib/Plugins/SearchEngine/Elastic8/FieldTypes/Weight.php
@@ -39,14 +39,8 @@ require_once(__CA_LIB_DIR__ . '/Plugins/SearchEngine/Elastic8/FieldTypes/Generic
 
 class Weight extends GenericElement {
 
-	public function __construct($table_name, $element_code) {
-		parent::__construct($table_name, $element_code);
-	}
-
 	public function getIndexingFragment($content, array $options): array {
-		if (is_array($content)) {
-			$content = serialize($content);
-		}
+		$content = $this->serializeIfArray($content);
 		if ($content == '') {
 			return parent::getIndexingFragment($content, $options);
 		}
@@ -58,6 +52,7 @@ class Weight extends GenericElement {
 			return parent::getIndexingFragment((float) $parsed_length->convertTo('KILOGRAM', 6, 'en_US'),
 				$options);
 		} catch (Exception $e) {
+			self::getLogger()->logError(__METHOD__ . ': ' . $e->getMessage());
 			return [];
 		}
 	}
@@ -93,6 +88,7 @@ class Weight extends GenericElement {
 				$term->field
 			);
 		} catch (Exception $e) {
+			self::getLogger()->logError(__METHOD__ . ': ' . $e->getMessage());
 			return $term;
 		}
 	}

--- a/app/lib/Plugins/SearchEngine/Elastic8/dynamicTemplates.json
+++ b/app/lib/Plugins/SearchEngine/Elastic8/dynamicTemplates.json
@@ -65,15 +65,6 @@
     }
   },
   {
-    "TODO remove this" : {
-      "match_mapping_type" : "*",
-      "match" : "*type_id",
-      "mapping" : {
-        "type" : "keyword"
-      }
-    }
-  },
-  {
     "floats" : {
       "match_mapping_type" : "*",
       "match" : "*-f",
@@ -133,20 +124,6 @@
       "match" : "*-dr",
       "mapping" : {
         "type" : "double_range"
-      }
-    }
-  },
-  {
-    "floats" : {
-      "match_mapping_type" : "*",
-      "match" : "*-f",
-      "mapping" : {
-        "type" : "float",
-        "fields" : {
-          "k" : {
-            "type" : "keyword"
-          }
-        }
       }
     }
   },
@@ -254,7 +231,7 @@
   {
     "content_ids" : {
       "match_mapping_type" : "*",
-      "match" : "*_content_ids",
+      "match" : "content_id",
       "mapping" : {
         "type" : "keyword"
       }


### PR DESCRIPTION
* Structure now:
```json
"ca_objects/entity_series_date": [
            {
              "-": "2005-2010",
              "-dtr": {
                "gte": "2005-01-01T00:00:00Z",
                "lte": "2010-12-31T23:59:59Z"
              },
              "content_id": 1
            }
          ]
```
* Remove duplicated code
* deprecate call to serialize
* Make index property key calculation DRYer
* Add logging for errors when parsing values
* Introduce suffixes as constants
* Change ElasticSearch dynamic templates
  * Remove temporary and duplicate dynamic templates
  * Change `*content_ids` to `content_id` as new structure expects that
* Add special handling for ListItem attributes
  * Use keyword rather than fulltext search
* Store content_id alongside actual value
* Make log level configurable via text value