### PR TITLE
PROVES-29 Support date range intrinsics using the same functionality as date range elements

### DIFF
--- a/app/lib/Plugins/SearchEngine/Elastic8/FieldTypes/DateRange.php
+++ b/app/lib/Plugins/SearchEngine/Elastic8/FieldTypes/DateRange.php
@@ -41,22 +41,8 @@ class DateRange extends GenericElement {
 
 	public function getIndexingFragment($content, array $options): array {
 		$content = $this->serializeIfArray($content);
-		$return = [];
 
-		if (!is_array($parsed_content = caGetISODates($content, ['returnUnbounded' => true]))) {
-			return $return;
-		}
-
-		$rewritten_start = caRewriteDateForElasticSearch($parsed_content["start"], true);
-		$rewritten_end = caRewriteDateForElasticSearch($parsed_content["end"], false);
-
-		$return[$this->getDataTypeSuffix()] = $content;
-		$return[$this->getDataTypeSuffix(self::SUFFIX_DATE_RANGE)] = [
-			'gte' => $rewritten_start,
-			'lte' => $rewritten_end
-		];
-
-		return [$this->getKey() => $return];
+		return $this->parseElasticsearchDateRange($content);
 	}
 
 	public function getFiltersForPhraseQuery(Zend_Search_Lucene_Search_Query_Phrase $query): array {
@@ -202,4 +188,5 @@ class DateRange extends GenericElement {
 
 		return $return;
 	}
+
 }

--- a/app/lib/Plugins/SearchEngine/Elastic8/FieldTypes/Intrinsic.php
+++ b/app/lib/Plugins/SearchEngine/Elastic8/FieldTypes/Intrinsic.php
@@ -47,6 +47,12 @@ class Intrinsic extends FieldType {
 			FT_NUMBER => self::SUFFIX_INTEGER,// TODO: Are there any FT_NUMBER which are not integer,
 			FT_TIMERANGE => self::SUFFIX_TIME_RANGE,
 			FT_TIMECODE => self::SUFFIX_TIME,
+			FT_DATE => self::SUFFIX_DATE,
+			FT_DATERANGE => self::SUFFIX_DATE_RANGE,
+			FT_DATETIME => self::SUFFIX_DATE,
+			FT_HISTORIC_DATE => self::SUFFIX_DATE,
+			FT_HISTORIC_DATERANGE => self::SUFFIX_DATE_RANGE,
+			FT_HISTORIC_DATETIME => self::SUFFIX_DATE,
 		];
 	protected const TOKENIZE_INCOMPATIBLE = [self::SUFFIX_BOOLEAN, self::SUFFIX_INTEGER, self::SUFFIX_TIME];
 
@@ -105,6 +111,14 @@ class Intrinsic extends FieldType {
 					$suffix = self::SUFFIX_KEYWORD;
 				}
 				break;
+			case (FT_DATE):
+			case (FT_DATERANGE):
+			case (FT_DATETIME):
+				return $this->parseElasticsearchDateRange($content);
+			case (FT_HISTORIC_DATE):
+			case (FT_HISTORIC_DATERANGE):
+			case (FT_HISTORIC_DATETIME):
+				return $this->parseElasticsearchDateRange($content, true);
 			default:
 				// noop (pm_content is just pm_content)
 				break;


### PR DESCRIPTION
* Historic timestamps (2020.01011200) get treated correctly as well.