### PR TITLE
ES fix for additional terms issue.

### DIFF
--- a/app/lib/Plugins/SearchEngine/Elastic8/Query.php
+++ b/app/lib/Plugins/SearchEngine/Elastic8/Query.php
@@ -362,7 +362,7 @@ class Query {
 				$additional_term_queries[] = new Zend_Search_Lucene_Search_Query_Term($additional_term);
 			}
 
-			return join(' AND ', $additional_term_queries);
+			return new Zend_Search_Lucene_Search_Query_Boolean($additional_term_queries);
 		} else {
 			return $original_subquery;
 		}


### PR DESCRIPTION
This approach gives a query that looks like: 

```
((+(ca_objects\/test_currency.-currency:23) +(ca_objects\/test_currency.-s:AUD))) AND (ca_objects\/deleted.-b:false AND (ca_objects\/type_id.-kw:26))
```

Which seems to work as intended

Alternate to https://github.com/gaiaresources/providence/pull/82