### PR TITLE
PROVES-116 Inspector record count inaccurate when paging through records

### DIFF
--- a/app/helpers/displayHelpers.php
+++ b/app/helpers/displayHelpers.php
@@ -800,6 +800,9 @@ jQuery(document).ready(function() {
 			$vs_back_text = "<span class='resultLink'>"._t('Results')."</span>";
 		}
 
+		// Allows navigation through the current page of results (as stored in $va_found_ids)
+		// See discussion on https://github.com/gaiaresources/providence/pull/90
+
 		$vs_buf = '';
 		if (is_array($va_found_ids) && sizeof($va_found_ids)) {
 			$default_to_summary_view_conf = $po_request->config->getList("{$vs_table_name}_editor_defaults_to_summary_view");
@@ -822,7 +825,6 @@ jQuery(document).ready(function() {
 				}
 				TooltipManager::add(".prev.record", "Previous"); 
 			} else {
-				// DO something to load previous page of results
 				$vs_buf .=  '<span class="prev disabled">'.caNavIcon(__CA_NAV_ICON_SCROLL_LT__, 2).'</span>';
 			}
 
@@ -841,7 +843,6 @@ jQuery(document).ready(function() {
 				}
 				TooltipManager::add(".next.record", "Next");
 			} else {
-				// DO somehting to load next page of results
 				$vs_buf .=  '<span class="next disabled">'.caNavIcon(__CA_NAV_ICON_SCROLL_RT__, 2).'</span>';
 			}
 		} elseif ($vn_item_id) {

--- a/app/helpers/displayHelpers.php
+++ b/app/helpers/displayHelpers.php
@@ -788,7 +788,9 @@ jQuery(document).ready(function() {
 		}
 
 		$va_found_ids 			= $po_result_context->getResultList();
+		$vn_total_count			= $po_result_context->getTotalCount();
 		$vn_current_pos			= $po_result_context->getIndexInResultList($vn_item_id);
+		$vn_total_pos			= (($po_result_context->getCurrentResultsPageNumber() - 1) * $po_result_context->getItemsPerPage()) + $vn_current_pos;
 		$vn_prev_id 			= $po_result_context->getPreviousID($vn_item_id);
 		$vn_next_id 			= $po_result_context->getNextID($vn_item_id);
 
@@ -820,12 +822,13 @@ jQuery(document).ready(function() {
 				}
 				TooltipManager::add(".prev.record", "Previous"); 
 			} else {
+				// DO something to load previous page of results
 				$vs_buf .=  '<span class="prev disabled">'.caNavIcon(__CA_NAV_ICON_SCROLL_LT__, 2).'</span>';
 			}
 
-			$vs_buf .= "<span class='resultCount'>".ResultContext::getResultsLinkForLastFind($po_request, $vs_table_name,  $vs_back_text, ''). " (".($vn_current_pos)."/".sizeof($va_found_ids).")</span>";
+			$vs_buf .= "<span class='resultCount'>".ResultContext::getResultsLinkForLastFind($po_request, $vs_table_name,  $vs_back_text, ''). " (".$vn_total_pos."/".$vn_total_count.")</span>";
 
-			if (!$vn_next_id && sizeof($va_found_ids)) { $vn_next_id = $va_found_ids[0]; }
+//			if (!$vn_next_id && sizeof($va_found_ids)) { $vn_next_id = $va_found_ids[0]; }
 			if ($vn_next_id > 0) {
 				if(
 					$po_request->user->canAccess($po_request->getModulePath(),$po_request->getController(),"Edit",array($vs_pk => $vn_next_id))
@@ -838,6 +841,7 @@ jQuery(document).ready(function() {
 				}
 				TooltipManager::add(".next.record", "Next");
 			} else {
+				// DO somehting to load next page of results
 				$vs_buf .=  '<span class="next disabled">'.caNavIcon(__CA_NAV_ICON_SCROLL_RT__, 2).'</span>';
 			}
 		} elseif ($vn_item_id) {

--- a/app/lib/BaseSearchController.php
+++ b/app/lib/BaseSearchController.php
@@ -239,8 +239,9 @@ class BaseSearchController extends BaseRefineableSearchController {
 				$vo_result->filterResult('ca_objects.type_id', $vn_show_type_id);
 			}
 	
+			$this->opo_result_context->setResultList($vo_result->getPrimaryKeyValues());
 			if($vb_is_new_search || $vb_criteria_have_changed || $vb_sort_has_changed || $this->type_restriction_has_changed) {
-				$this->opo_result_context->setResultList($vo_result->getPrimaryKeyValues());
+//				$this->opo_result_context->setResultList($vo_result->getPrimaryKeyValues());
 				$this->opo_result_context->setParameter('availableVisualizationChecked', 0);
 				//if ($this->opo_result_context->searchExpressionHasChanged()) { $vn_page_num = 1; }
 				$this->opo_result_context->setCurrentResultsPageNumber(1);

--- a/app/lib/BaseSearchController.php
+++ b/app/lib/BaseSearchController.php
@@ -238,7 +238,8 @@ class BaseSearchController extends BaseRefineableSearchController {
 				$this->view->setVar('show_type_id', $vn_show_type_id);
 				$vo_result->filterResult('ca_objects.type_id', $vn_show_type_id);
 			}
-	
+
+			// Refresh result list in context to ensure it has the current "page" of results.
 			$this->opo_result_context->setResultList($vo_result->getPrimaryKeyValues());
 			if($vb_is_new_search || $vb_criteria_have_changed || $vb_sort_has_changed || $this->type_restriction_has_changed) {
 //				$this->opo_result_context->setResultList($vo_result->getPrimaryKeyValues());

--- a/app/lib/BaseSearchController.php
+++ b/app/lib/BaseSearchController.php
@@ -241,6 +241,7 @@ class BaseSearchController extends BaseRefineableSearchController {
 
 			// Refresh result list in context to ensure it has the current "page" of results.
 			$this->opo_result_context->setResultList($vo_result->getPrimaryKeyValues());
+			$this->opo_result_context->setTotalCount($vo_result->numHits());
 			if($vb_is_new_search || $vb_criteria_have_changed || $vb_sort_has_changed || $this->type_restriction_has_changed) {
 //				$this->opo_result_context->setResultList($vo_result->getPrimaryKeyValues());
 				$this->opo_result_context->setParameter('availableVisualizationChecked', 0);

--- a/app/lib/ResultContext.php
+++ b/app/lib/ResultContext.php
@@ -283,6 +283,29 @@ class ResultContext {
 	}
 	# ------------------------------------------------------------------
 	/**
+	 * Returns total count from the context's operation.
+	 *
+	 * @return int - total count
+	 */
+	public function getTotalCount() {
+		if ($va_context = $this->getContext()) {
+			return $va_context['total_count'] ?? null;
+		}
+		return null;
+	}
+	# ------------------------------------------------------------------
+	/**
+	 * Sets the total count for the current context.
+	 *
+	 * @param $pn_total_count - Total number of results found
+	 *
+	 * @return int - Total number of results found
+	 */
+	public function setTotalCount($pn_total_count) {
+		return $this->setContextValue('total_count', $pn_total_count);
+	}
+	# ------------------------------------------------------------------
+	/**
 	 * Returns number of items in the result list from the context's operation. 
 	 *
 	 * @return int


### PR DESCRIPTION
This change allows you to navigate through the current pager result list

![image](https://github.com/gaiaresources/providence/assets/53800058/a29eea3b-9b4a-40db-96c8-2535212ef29a)

I might need some help/feedback from @kehh in regards to expected functionality and also if there is a more specific scenario where we need to update the result context instead of every time.