### PR TITLE
PROVES-137 Fatal error on incorrectly formatted date range search

### DIFF
--- a/app/lib/Plugins/SearchEngine/Elastic8/Query.php
+++ b/app/lib/Plugins/SearchEngine/Elastic8/Query.php
@@ -316,7 +316,8 @@ class Query {
 						foreach ($fld->getFiltersForPhraseQuery($subquery) as $filter) {
 							$this->additional_filters[] = $filter;
 						}
-						break;
+						// return without new subquery as this is applied through additional filters only.
+						return;
 					} else {
 						if ($rewritten_term = $fld->getRewrittenTerm($term)) {
 							if ($multiterm_all_terms_same_field) {


### PR DESCRIPTION
@kehh It doesn't look like we should be throwing an error in this scenario as the date filters are being applied as "additional filters" so there is no subquery to return, but it's still valid.

Seems to work in my limited local testing.