### PR TITLE
PROVES-145 RDL Importer results context.

### DIFF
--- a/app/lib/ResultContext.php
+++ b/app/lib/ResultContext.php
@@ -231,7 +231,7 @@ class ResultContext {
 	 * @return integer - number of page; the first page is 1 (*not* zero). Returns 1 as default if no page has been set for the current context.
 	 */
 	public function getCurrentResultsPageNumber() {
-		if (($pn_page = intval($this->opo_request->getParameter('page', pString, ['forcePurify' => true]))) < 1) { 
+		if ($pn_page = (!$this->opo_request || intval($this->opo_request->getParameter('page', pString, ['forcePurify' => true])) < 1)) {
 			// no page in request so fetch from context 
 			if ($va_context = $this->getContext()) {
 				$pn_page = $va_context['page'] ?? 1;
@@ -346,7 +346,7 @@ class ResultContext {
 	 * @return int - number of items to display per results page, or null if no value is set
 	 */
 	public function getItemsPerPage() {
-		if (!($pn_items_per_page = $this->opo_request->getParameter('n', pInteger))) {
+		if (!($pn_items_per_page = !$this->opo_request || $this->opo_request->getParameter('n', pInteger))) {
 			if ($va_context = $this->getContext()) {
 				return $va_context['num_items_per_page'] ?? null;
 			}


### PR DESCRIPTION
@kehh whitescreen of death caused by `$this->opo_request` being null in both `getItemsPerPage()` and `getCurrentResultsPageNumber()` called from `displayHelpers.php` uncertain if the request should exist or if we should handle the request not existing, this currently takes the later approach. 