### PR TITLE
Add hooks for before and after bundle delete

### DIFF
--- a/app/lib/BundlableLabelableBaseModelWithAttributes.php
+++ b/app/lib/BundlableLabelableBaseModelWithAttributes.php
@@ -425,8 +425,12 @@ class BundlableLabelableBaseModelWithAttributes extends LabelableBaseModelWithAt
 
 		$vn_primary_key = $this->getPrimaryKey();
 		SearchResult::clearResultCacheForRow($this->tableName(), $this->getPrimaryKey());
-		
+
+		$this->opo_app_plugin_manager->hookBeforeBundleDelete(array('id' => $this->getPrimaryKey(), 'table_num' => $this->tableNum(), 'table_name' => $this->tableName(), 'instance' => $this));
+
 		$vn_rc = parent::delete($pb_delete_related, $pa_options, $pa_fields, $pa_table_list);
+
+		$this->opo_app_plugin_manager->hookAfterBundleDelete(array('id' => $this->getPrimaryKey(), 'table_num' => $this->tableNum(), 'table_name' => $this->tableName(), 'instance' => $this));
 
 		return $vn_rc;
 	}


### PR DESCRIPTION
Adding these hooks seems to trigger as expected and has the item information still.